### PR TITLE
Fix NoSuchPathError in get_modified_packs

### DIFF
--- a/build_related_scripts/get_modified_packs.py
+++ b/build_related_scripts/get_modified_packs.py
@@ -42,7 +42,7 @@ def get_changed_files(repo_path: Path, prev_ver: str) -> List[str]:
         List[str]. All the files that have changed.
     """
     repo = Repo(repo_path, search_parent_directories=True)
-    git_util = GitUtil(repo)
+    git_util = GitUtil(repo_path)
 
     if str(repo.active_branch) == prev_ver:
         # Get the latest commit in master, prior the merge.


### PR DESCRIPTION
As raised by @tlium in this [DFIR Slack thread](https://dfircommunity.slack.com/archives/CMWN08YB1/p1705485468744549), users were unable to use the `get_modified_packs.py` script.

```bash
% python build_related_scripts/get_modified_packs.py -rp /path/to/repo --prev-ver main
Traceback (most recent call last):
  File "/path/to/repo/build_related_scripts/get_modified_packs.py", line 75, in <module>
    main()
  File "/path/to/repo/build_related_scripts/get_modified_packs.py", line 66, in main
    changed_files = get_changed_files(repo_path, prev_ver)
  File "/path/to/repo/build_related_scripts/get_modified_packs.py", line 45, in get_changed_files
    git_util = GitUtil(repo)
  File "/path/to/repo/venv/lib/python3.10/site-packages/demisto_sdk/commands/common/git_util.py", line 61, in __init__
    self.repo = Repo(
  File "/path/to/repo/venv/lib/python3.10/site-packages/git/repo/base.py", line 215, in __init__
    raise NoSuchPathError(epath)
git.exc.NoSuchPathError: /path/to/repo/<git.repo.base.Repo '/path/to/repo/.git'>
```

Upon troubleshooting, it was found that the issue was caused because we’re passing an instance of a `git.repo.base.Repo` class into [`demisto_sdk.commands.common.git_util.GitUtil` method](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/common/git_util.py#L51) when it’s expecting an `str|pathlib.Path` type.

![image](https://github.com/demisto/content-ci-cd-template/assets/85439776/1899942a-27b3-44ee-aed9-f9a38e5fbb6d)

This PR was opened to fix this issue.